### PR TITLE
External dependency reduction, part 1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Mandatory settings
+
+## OpenAI API key
+OPENAI_API_KEY=
+
+## Telegram bot token, acquired from the BotFather
+TELEGRAM_BOT_TOKEN=
+
+## Telegram bot name, used when @mention-ing it
+TELEGRAM_BOT_NAME=
+
+# Optional settings
+AZURE_OPENAI_KEY=
+
+FACEBOOK_GRAPH_VERSION=
+WHATSAPP_BOT_TOKEN=
+WHATSAPP_PHONE_NUMBER_ID=
+WHATSAPP_PHONE_NUMBER=
+
+DB_CONNECTION_STRING=
+SQS_QUEUE_URL=
+
+DREAMSTUDIO_API_KEY=
+
+POSTHOG_API_KEY=
+
+SERPER_API_KEY=
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
-.env.*
+.env.dev
+.env.prod
 handleMessages.zip
 logs/
 __pycache__/

--- a/src/infra/utils.py
+++ b/src/infra/utils.py
@@ -39,3 +39,7 @@ def load_env():
 
     load_dotenv(f"./.env.{stage}")
 
+    # If no database is provided, resort to a locally-hosted SQLite version.
+    # Typically used for testing.
+    if os.environ['DB_CONNECTION_STRING'] == '':
+        os.environ['DB_CONNECTION_STRING'] = 'sqlite:///file::memory:?cache=shared'

--- a/src/services/messengers/tg.py
+++ b/src/services/messengers/tg.py
@@ -11,6 +11,8 @@ from box import Box
 
 import threading
 
+TELEGRAM_SENDER_ID = os.environ['TELEGRAM_BOT_TOKEN'].split(':')[0]
+
 class TelegramMessenger(MessagingService):
     
     def _get_message_kind(self, message) -> Optional[str]:
@@ -30,7 +32,7 @@ class TelegramMessenger(MessagingService):
         chat_type = message['chat']['type']
         chat_id = str(message['chat']['id'])
         sender_id = str(message['from']['id'])
-        is_sent_by_me = message['from']['id'] == int(os.environ['TELEGRAM_SENDER_ID'])
+        is_sent_by_me = message['from']['id'] == int(TELEGRAM_SENDER_ID)
         is_forwarded = message.get('forward_from', None) != None
         messageId = str(message['message_id'])
         reply_to_message_id = message['reply_to_message']['message_id'] if 'reply_to_message' in message else None
@@ -104,7 +106,7 @@ class TelegramMessenger(MessagingService):
         if msg.body.startswith(f'@{os.environ["TELEGRAM_BOT_NAME"]}'):
             return True
 
-        if 'reply_to_message' in msg.rawSource and msg.rawSource['reply_to_message']['from']['id'] == int(os.environ['TELEGRAM_SENDER_ID']):
+        if 'reply_to_message' in msg.rawSource and msg.rawSource['reply_to_message']['from']['id'] == int(TELEGRAM_SENDER_ID):
             return True
 
         return False

--- a/src/services/open_ai/query_openai.py
+++ b/src/services/open_ai/query_openai.py
@@ -15,6 +15,7 @@ from services.token_prediction import token_predictor
 from infra.context import Context
 from langchain.utilities import google_serper
 
+OPENAI_SPEECH_TO_TEXT_MODEL = 'whisper-1'
 
 openai.api_key = os.environ['OPENAI_API_KEY']
 
@@ -347,6 +348,10 @@ def chat_completion_create_wrap(ctx: Context, model, messages):
         return response
 
     if model == 'gpt-3.5-turbo':
+        # TODO: cleanup per issue #55
+        if os.environ['AZURE_OPENAI_KEY'] == '':
+            return openai.ChatCompletion().create(model=model, messages=messages, temperature=0.2)
+
         url = "https://r1x.openai.azure.com/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-05-15"
 
         headers = {


### PR DESCRIPTION
1. Introduce minimal set of required environment variables with .env.example
   Also includes simplifying some requirements.

2. Remove external dependencies to enable more developers
   - Telegram: reduce number of environment variables from 3 to 2.
   - Speech model: hard-code to whisper-1.
   - Posthog: no longer a requirement. Not logging if no Posthog API key.
   - PostgreSQL: no longer a requirement. Using in-memory SQLite instance if no connection string.

Related to #51.